### PR TITLE
Initial expense schema

### DIFF
--- a/examples/expense.json
+++ b/examples/expense.json
@@ -1,0 +1,9 @@
+{
+  "title": "Server rent",
+  "description": "Dedicated server: andromeda.kosmos.org, April 2020",
+  "currency": "EUR",
+  "amount": 39.00,
+  "date": "2020-05-06",
+  "url": "https://wiki.kosmos.org/Infrastructure#Hetzner",
+  "tags": ["infrastructure", "server", "hetzner"]
+}

--- a/schemas/expense.json
+++ b/schemas/expense.json
@@ -1,0 +1,102 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://schema.kosmos.org/Expense",
+  "type": "object",
+  "title": "Expense",
+  "description": "Record of costs expended",
+  "default": {},
+  "required": [
+    "title",
+    "currency",
+    "amount"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "@context": {
+      "type": "string",
+      "enum": [ "https://schema.kosmos.org" ],
+      "default": "https://schema.kosmos.org"
+    },
+    "@type": {
+      "type": "string",
+      "enum": [ "Expense" ],
+      "default": "Expense"
+    },
+    "title": {
+      "type": "string",
+      "title": "Title",
+      "description": "A short description of the expense",
+      "default": "",
+      "examples": [
+        "Server rent"
+      ]
+    },
+    "description": {
+      "type": "string",
+      "title": "Description",
+      "description": "A longer description of the expense",
+      "default": "",
+      "examples": [
+        "Dedicated server: andromeda.kosmos.org"
+      ]
+    },
+    "currency": {
+      "type": "string",
+      "title": "Currency",
+      "description": "ISO 4217 (or other) code of the currency that the expense was paid with",
+      "default": "",
+      "examples": [
+        "EUR",
+        "USD",
+        "BTC"
+      ]
+    },
+    "amount": {
+      "type": "number",
+      "title": "Amount",
+      "description": "Expended amount of defined currency",
+      "default": 0,
+      "examples": [
+        42.0
+      ]
+    },
+    "date": {
+      "type": "string",
+      "format": "date",
+      "title": "Date",
+      "description": "Date of contribution (RFC 3339 full-date)"
+    },
+    "url": {
+      "type": "string",
+      "format": "uri",
+      "title": "URL",
+      "description": "A URL pointing to more information about the expense or related items",
+      "default": "",
+      "examples": [
+        "https://wiki.kosmos.org/Infrastructure#Hetzner"
+      ]
+    },
+    "tags": {
+      "type": "array",
+      "title": "Tags",
+      "description": "Tags for organizing, filtering, sorting, etc.",
+      "default": [],
+      "items": {
+        "$id": "#/properties/tags/items",
+        "anyOf": [
+          {
+            "$id": "#/properties/tags/items/anyOf/0",
+            "type": "string",
+            "title": "Tag",
+            "description": "A tag (lowercase dasherized)",
+            "default": "",
+            "examples": [
+              "infrastructure",
+              "server"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/schemas/expense.json
+++ b/schemas/expense.json
@@ -10,7 +10,7 @@
     "currency",
     "amount"
   ],
-  "additionalProperties": false,
+  "additionalProperties": true,
   "properties": {
     "@context": {
       "type": "string",
@@ -97,6 +97,11 @@
           }
         ]
       }
+    },
+    "details": {
+      "type": "object",
+      "title": "Tag",
+      "properties": {}
     }
   }
 }

--- a/schemas/expense.json
+++ b/schemas/expense.json
@@ -82,10 +82,8 @@
       "description": "Tags for organizing, filtering, sorting, etc.",
       "default": [],
       "items": {
-        "$id": "#/properties/tags/items",
         "anyOf": [
           {
-            "$id": "#/properties/tags/items/anyOf/0",
             "type": "string",
             "title": "Tag",
             "description": "A tag (lowercase dasherized)",

--- a/schemas/expense.json
+++ b/schemas/expense.json
@@ -64,7 +64,7 @@
       "type": "string",
       "format": "date",
       "title": "Date",
-      "description": "Date of contribution (RFC 3339 full-date)"
+      "description": "Date when expense was logged/proposed (RFC 3339 full-date)"
     },
     "url": {
       "type": "string",


### PR DESCRIPTION
Add schema and example for expense records.

I would create documents as arrays of expenses by default, so that it's easy to bundle them from the get-go.

refs 67P/kredits-contracts#48