### PR TITLE
Move npm package to @kosmos namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
-This repository/module contains [JSON Schema](https://json-schema.org/) definitions as well as examples for
-[Kosmos](https://kosmos.org) data formats.
+[![npm](https://img.shields.io/npm/v/@kosmos/schemas)](https://www.npmjs.com/package/@kosmos/schemas)
+
+This repository/module contains [JSON Schema](https://json-schema.org/)
+definitions as well as examples for [Kosmos](https://kosmos.org) data formats.
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "kosmos-schemas",
+  "name": "@kosmos/schemas",
   "version": "2.2.0",
   "description": "JSON-LD schemas for Kosmos data formats",
   "main": "index.js",


### PR DESCRIPTION
Also adds a link to npm, with the version displayed.

I published a README with deprecation warning and link to the new package to https://www.npmjs.com/package/kosmos-schemas already.

I also published the last release to the namespace already: https://www.npmjs.com/package/@kosmos/schemas